### PR TITLE
fix for gtk+ 2.22 used on Ubuntu 10.10

### DIFF
--- a/gtksheet/gtkitementry.c
+++ b/gtksheet/gtkitementry.c
@@ -143,7 +143,11 @@ static void         gtk_entry_draw_cursor              (GtkEntry       *entry,
 static PangoLayout *gtk_entry_ensure_layout            (GtkEntry       *entry,
                                                         gboolean        include_preedit);
 static void         gtk_entry_queue_draw               (GtkEntry       *entry);
+
+#if (GTK_MAJOR_VERSION == 2 && GTK_MINOR_VERSION < 22)
 static void         gtk_entry_reset_im_context         (GtkEntry       *entry);
+#endif
+
 static void         gtk_entry_recompute                (GtkEntry       *entry);
 static void         gtk_entry_get_cursor_locations     (GtkEntry       *entry,
 							CursorType      type,
@@ -1868,6 +1872,7 @@ gtk_entry_queue_draw (GtkEntry *entry)
     gdk_window_invalidate_rect (entry->text_area, NULL, FALSE);
 }
 
+#if (GTK_MAJOR_VERSION == 2 && GTK_MINOR_VERSION < 22)
 static void
 gtk_entry_reset_im_context (GtkEntry *entry)
 {
@@ -1877,6 +1882,7 @@ gtk_entry_reset_im_context (GtkEntry *entry)
       gtk_im_context_reset (entry->im_context);
     }
 }
+#endif
 
 static void
 gtk_entry_get_cursor_locations (GtkEntry   *entry,


### PR DESCRIPTION
gtk+ 2.22 already includes  the gtk_entry_reset_im_context in it's api.

so I just removed it for any version above 2.22.
