### PR TITLE
suppress pixman_region32_init_rect warnings (issue 15)

### DIFF
--- a/gtksheet/gtksheet.c
+++ b/gtksheet/gtksheet.c
@@ -14017,7 +14017,7 @@ _gtk_sheet_row_buttons_size_allocate(GtkSheet *sheet)
     if (sheet->column_titles_visible)
     {
         /* negative height can result in pixman invalid rectangle warnings */ 
-        if (height > sheet->column_title_area.height)
+        if (height >= sheet->column_title_area.height)
 	    height -= sheet->column_title_area.height;
 	y = sheet->column_title_area.height;
     }

--- a/gtksheet/gtksheet.c
+++ b/gtksheet/gtksheet.c
@@ -14016,7 +14016,9 @@ _gtk_sheet_row_buttons_size_allocate(GtkSheet *sheet)
 
     if (sheet->column_titles_visible)
     {
-	height -= sheet->column_title_area.height;
+        /* negative height can result in pixman invalid rectangle warnings */ 
+        if (height > sheet->column_title_area.height)
+	    height -= sheet->column_title_area.height;
 	y = sheet->column_title_area.height;
     }
 

--- a/gtksheet/gtksheetcolumn.c
+++ b/gtksheet/gtksheetcolumn.c
@@ -1332,7 +1332,7 @@ _gtk_sheet_column_buttons_size_allocate(GtkSheet *sheet)
     if (sheet->row_titles_visible)
     {
         /* negative widths can result in pixman_region32_init_rect warnings */
-        if (width > sheet->row_title_area.width) 
+        if (width >= sheet->row_title_area.width) 
             width -= sheet->row_title_area.width;
         x = sheet->row_title_area.width;
     }

--- a/gtksheet/gtksheetcolumn.c
+++ b/gtksheet/gtksheetcolumn.c
@@ -1331,7 +1331,9 @@ _gtk_sheet_column_buttons_size_allocate(GtkSheet *sheet)
 
     if (sheet->row_titles_visible)
     {
-        width -= sheet->row_title_area.width;
+        /* negative widths can result in pixman_region32_init_rect warnings */
+        if (width > sheet->row_title_area.width) 
+            width -= sheet->row_title_area.width;
         x = sheet->row_title_area.width;
     }
 


### PR DESCRIPTION
This patch removes the warning messages:
   *** BUG ***
   In pixman_region32_init_rect: Invalid rectangle passed
   Set a breakpoint on '_pixman_log_error' to debug

which appear in the 4.3.3 release of gtksheet. The warnings occur when _gtk_sheet_row_buttons_size_allocate or _gtk_sheet_column_buttons_size_allocate are called where the calculations of width/height result in a negative value. The invalid (negative) width/height results in an invalid rectangle.  

It appears that gtksheet initializes the sheet to:

    sheet->sheet_window_width = 0;
    sheet->sheet_window_height = 0;
    sheet->column_title_area.height = _gtk_sheet_row_default_height(GTK_WIDGET(sheet));
    sheet->row_title_area.width = GTK_SHEET_COLUMN_DEFAULT_WIDTH;

and  then in the button allocations in gtksheet.c/gtksheetcolumn.c subtracts the title_area.width/height from the sheet_window_width/height, the subtraction results in a negative value.

This patch prevents the negative width/height so the warning does not appear. It does not address why the initial values can result in a negative width/height.