### PR TITLE
Fix GCC 10 compilation

### DIFF
--- a/gtksheet/gtksheet.h
+++ b/gtksheet/gtksheet.h
@@ -83,7 +83,7 @@ typedef enum
     GTK_SHEET_RANGE_SELECTED
 } GtkSheetState;
 
-enum
+typedef enum
 {
     GTK_SHEET_LEFT_BORDER     = 1 << 0,
     GTK_SHEET_RIGHT_BORDER    = 1 << 1,


### PR DESCRIPTION
This fixes a compilation error with GCC 10, due to [`-fno-common` being switched on by default][0]. 

Building this causes some other `.c` files to be regenerated differently, but I decided not to commit those to not hide the relevant change.

If you don't like this fix for whatever reason, the alternative is to stick `-fcommon` in the `CFLAGS`.

 [0]: https://gcc.gnu.org/gcc-10/changes.html