### PR TITLE
Remove duplicate AC_CONFIG_MACRO_DIR call

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4,7 +4,6 @@
 AC_INIT([GtkSheet], [4.3.5])
 
 AC_LANG([C])
-AC_CONFIG_MACRO_DIR([m4])
 
 # Save this value here, since automake will set cflags later
 cflags_set=${CFLAGS:+set}


### PR DESCRIPTION
This call is repeated later on in the file. Newer versions of `configure` will error out on the duplicate call. As far as I can tell, this doesn't change any behaviour.